### PR TITLE
Settings: add config options to disable config variable expansion

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -227,6 +227,11 @@ x_content_type_options = true
 # when they detect reflected cross-site scripting (XSS) attacks.
 x_xss_protection = true
 
+# Set to true to disable config variable expansion from environment variables
+disable_evn_variable_expansion = false
+
+# Set to true to disable config variable expansion from a file path
+disable_file_variable_expansion = false
 
 #################################### Snapshots ###########################
 [snapshots]

--- a/pkg/setting/expanders.go
+++ b/pkg/setting/expanders.go
@@ -43,6 +43,17 @@ func AddExpander(name string, priority int64, e Expander) {
 	})
 }
 
+func removeExpander(name string) {
+	n := 0
+	for _, x := range expanders {
+		if x.name != name {
+			expanders[n] = x
+			n++
+		}
+	}
+	expanders = expanders[:n]
+}
+
 var regex = regexp.MustCompile(`\$(|__\w+){([^}]+)}`)
 
 func expandConfig(file *ini.File) error {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -267,6 +267,8 @@ type Cfg struct {
 	CookieSecure                     bool
 	CookieSameSiteDisabled           bool
 	CookieSameSiteMode               http.SameSite
+	DisableEnvVariableExpansion      bool
+	DisableFileVariableExpansion     bool
 
 	TempDataLifetime         time.Duration
 	PluginsEnableAlpha       bool
@@ -627,6 +629,18 @@ func (cfg *Cfg) loadConfiguration(args *CommandLineArgs) (*ini.File, error) {
 
 	// apply command line overrides
 	applyCommandLineProperties(commandLineProps, parsedFile)
+
+	// enable or disable env and file variable expansion
+	if security := parsedFile.Section("security"); security != nil {
+		cfg.DisableEnvVariableExpansion = security.Key("disable_env_variable_expansion").MustBool(false)
+		cfg.DisableFileVariableExpansion = security.Key("disable_file_variable_expansion").MustBool(false)
+	}
+	if cfg.DisableEnvVariableExpansion {
+		removeExpander("env")
+	}
+	if cfg.DisableFileVariableExpansion {
+		removeExpander("file")
+	}
 
 	// evaluate config values containing environment variables
 	err = expandConfig(parsedFile)

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -289,6 +289,20 @@ func TestLoadingSettings(t *testing.T) {
 			So(value, ShouldEqual, "default_url_val")
 		})
 	})
+
+	Convey("Test disabling variable expansion from env and file", t, func() {
+		cfg := NewCfg()
+		os.Setenv("APP_MODE", "production")
+		err := cfg.Load(&CommandLineArgs{
+			HomePath: "../../",
+			Config:   filepath.Join(HomePath, "pkg/setting/testdata/expansion.ini"),
+		})
+
+		So(err, ShouldBeNil)
+
+		So(Env, ShouldEqual, "$__env{APP_MODE}")
+		So(cfg.MetricsEndpointBasicAuthPassword, ShouldEqual, "$__file{/etc/secrets/metrics_password}")
+	})
 }
 
 func TestParseAppUrlAndSubUrl(t *testing.T) {

--- a/pkg/setting/testdata/expansion.ini
+++ b/pkg/setting/testdata/expansion.ini
@@ -1,0 +1,8 @@
+app_mode = $__env{APP_MODE}
+
+[metrics]
+basic_auth_password = $__file{/etc/secrets/metrics_password}
+
+[security]
+disable_env_variable_expansion = true
+disable_file_variable_expansion = true


### PR DESCRIPTION
Adds two configuration options that allow disabling config variable expansion from environment variables and files.